### PR TITLE
Make tests run sequentially

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,6 +1,6 @@
 #! env ruby
 
-files = Dir.glob("src/**/*.re").map {|re_file| re_file.sub(".re", ".bs.js")}
+files = Dir.glob("src/**/*.re").map {|re_file| re_file.sub(".re", ".bs.js")}.sort
 files.each {|f| 
   puts "\n\n\n#{'*'*15}  #{f}"
   break unless system("node #{f}")


### PR DESCRIPTION
A simple sort to Dir.glob so that tests run sequentially, and not out of order.