### PR TITLE
Remove rtop from the first exercise

### DIFF
--- a/src/exercises/01-introduction/introduction.re
+++ b/src/exercises/01-introduction/introduction.re
@@ -23,15 +23,6 @@
 
     $ npm run start
 
-  You can also execute code in Reason's REPL (rtop) directly. To start rtop from
-  your terminal run:
-
-    $ rtop
-
-  Now try pasting the code below into it.
-
-  *Note:* Use `Ctrl-d` to exit the rtop session.
-
-  Try these out and move on to the next exercise!
+  Try this out and move on to the next exercise!
  */
 let () = print_endline("Hello, World!);


### PR DESCRIPTION
When https://github.com/protoship/learn-reasonml-workshop/commit/55cb783baf8dbb5a29c841734d780c241992bfec was merged earlier this year it means `rtop` is no longer installed (it was part of `reason-cli`). This makes the first exercise quite confusing; this PR just removes mention of it.